### PR TITLE
Offer resource type must always be lowercased

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "bundlesize": [
     {
       "path": "./bundle.js",
-      "maxSize": "3.2 kB"
+      "maxSize": "3.3 kB"
     }
   ],
   "prettier": {

--- a/src/node.test.ts
+++ b/src/node.test.ts
@@ -12,6 +12,10 @@ const expectedSignature = encodeURIComponent(
   "type=master&ver=1.0&sig=dFkNJGBUXu+ggUJnH1qh+7S1K7BcFdYYtxggMonBH8I="
 )
 
+const expectedOfferSignature = encodeURIComponent(
+  "type=master&ver=1.0&sig=bziS8AttbML5q2P+A1nZfrGJfARdVM0G678XPMURYEY="
+)
+
 const expectedHeaders = {
   Authorization: expectedSignature,
   "x-ms-date": date.toUTCString()
@@ -33,5 +37,14 @@ const headers = generateHeaders(
   date
 )
 
+const offerSignature = generateSignature(
+  masterKey,
+  method,
+  "offers",
+  "FooBar",
+  date
+)
+
 assert.deepStrictEqual(expectedSignature, signature)
+assert.deepStrictEqual(expectedOfferSignature, offerSignature)
 assert.deepStrictEqual(expectedHeaders, headers)

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -27,6 +27,10 @@ export function Signer(hmac: (key: string, message: string) => string) {
     resourceId: string = "",
     date: Date = new Date()
   ) {
+    // Offer must always be lowercased: See https://docs.microsoft.com/en-us/rest/api/cosmos-db/get-an-offer
+    if (resourceType === "offers") {
+      resourceId = resourceId.toLowerCase()
+    }
     var text =
       method.toLowerCase() +
       "\n" +


### PR DESCRIPTION
Upstream a change introduced in https://github.com/Azure/azure-cosmos-js/pull/224/files